### PR TITLE
fix: use version-only release name template in chart-releaser

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -50,6 +50,7 @@ jobs:
           mark_as_latest: false
           pages_branch: master
           pages_index_path: docs/_helm_chart/index/index.yaml
+          release_name_template: "{{ .Version }}"
         env:
           CR_TOKEN: "${{secrets.GITHUB_TOKEN}}"
 


### PR DESCRIPTION
By default, chart-releaser prefixes the chart name to the release tag (e.g. mercator-2026.04.27), but GitHub releases use only the version (e.g. 2026.04.27). This mismatch causes 404 errors when Helm tries to download chart assets from the index.yaml URLs.

Setting release_name_template to {{ .Version }} aligns the release tag format with the actual GitHub release tags.